### PR TITLE
Styling the component teaser

### DIFF
--- a/example.css
+++ b/example.css
@@ -1,10 +1,7 @@
 @import './index.css';
 @import '@economist/component-typography';
 @import '@economist/component-palette';
-
-ul {
-  list-style: none;
-}
+@import '@economist/component-grid';
 
 a {
   text-decoration: none;

--- a/example.css
+++ b/example.css
@@ -1,4 +1,3 @@
-@import './index.css';
 @import '@economist/component-typography';
 @import '@economist/component-palette';
 @import '@economist/component-grid';
@@ -10,3 +9,19 @@ a {
 .teaser {
   font-family: var(--fontfamily-body);
 }
+
+html {
+  line-height: var(--text-line-height-body-on-step-0);
+  font-size: 18px;
+}
+
+body {
+  background: white;
+}
+
+@media screen and (min-width: 800px) {
+  html {
+    font-size: 20px;
+  }
+}
+@import './index.css';

--- a/example.css
+++ b/example.css
@@ -1,0 +1,15 @@
+@import './index.css';
+@import '@economist/component-typography';
+@import '@economist/component-palette';
+
+ul {
+  list-style: none;
+}
+
+a {
+  text-decoration: none;
+}
+
+.teaser {
+  font-family: var(--fontfamily-body);
+}

--- a/index.css
+++ b/index.css
@@ -1,5 +1,4 @@
-@custom-media --viewport-small (width <= 568px);
-@custom-media --viewport-big (width >= 900px);
+@custom-media --viewport-big (width >= 36rem);
 
 .teaser {
   font-size: 1rem;
@@ -8,41 +7,65 @@
 .teaser__group-text {
   display: flex;
   flex-direction: column;
+  max-width: calc(1rem*30);
 }
 
 .teaser__title {
   font-size: var(--text-size-step-3);
-  font-weight: bold;
   line-height: var(--text-line-height-body-bold-on-step-3);
+  letter-spacing: var(--text-letter-spacing-body-bold-on-step-3);
+  font-weight: bold;
+  font-family: 'Halifax Bold';
   color: var(--color-beijing);
   order: 2;
+  margin: 0;
 }
 
 .teaser__flytitle {
-  font-size: var(--text-size-step-2);
-  line-height: var(--text-line-height-body-on-step-2);
+  font-size: var(--text-size-step-0);
+  line-height: var(--text-line-height-body-on-step-0);
+  font-weight: lighter;
+  font-family: 'Halifax Light';
   color: var(--color-economist);
   order: 1;
+  margin: 0;
+  margin-bottom: var(--grid-spacing-mouse);
 }
 
 .teaser__text {
-  font-size: var(--text-size-step-1);
-  line-height: var(--text-line-height-body-on-step-1);
+  font-size: var(--text-size-step-0);
+  line-height: var(--text-line-height-body-light-on-step-0);
+  font-weight: lighter;
+  font-family: 'Halifax Light';
   color: var(--color-beijing);
   order: 3;
+  margin-top: var(--grid-spacing-rabbit);
 }
 
 .teaser__datetime {
-  font-size: var(--text-size-step--1);
-  line-height: var(--text-line-height-body-on-step-1);
-  color: var(--color-london);
+  font-size: var(--text-size-step--2);
+  line-height: var(--text-line-height-body-light-on-step--2);
+  letter-spacing: var(--text-letter-spacing-body-light-on-step--2);
+  font-weight: lighter;
+  font-family: 'Halifax Light';
+  color: var(--color-moscow);
   order: 4;
+  margin-top: var(--grid-spacing-rabbit);
 }
 
-@media (--viewport-small) {
-  .teaser__img {
-    width: 100%;
-  }
+.teaser__datetime:before {
+  content: '';
+  width: 3rem;
+  height: 0.1rem;
+  background-color: var(--color-berlin);
+  display: block;
+  margin-bottom: var(--grid-spacing-hedgehog);
+}
+
+.teaser__img {
+  min-width: 200px;
+  width: 70%;
+  margin-bottom: var(--grid-spacing-sheep);
 }
 
 @media (--viewport-big) {
@@ -51,5 +74,9 @@
   }
   .teaser__group-image {
     margin-right: var(--grid-gutter-m);
+  }
+  .teaser__img {
+    width: 100%;
+    max-width: 15em;
   }
 }

--- a/index.css
+++ b/index.css
@@ -2,7 +2,7 @@
   font-size: 1rem;
 }
 
-.teaser__link {
+.teaser__group-text {
   display: flex;
   flex-direction: column;
 }

--- a/index.css
+++ b/index.css
@@ -1,3 +1,6 @@
+@custom-media --viewport-small (width <= 568px);
+@custom-media --viewport-big (width >= 900px);
+
 .teaser {
   font-size: 1rem;
 }
@@ -9,6 +12,7 @@
 
 .teaser__title {
   font-size: var(--text-size-step-3);
+  font-weight: bold;
   line-height: var(--text-line-height-body-bold-on-step-3);
   color: var(--color-beijing);
   order: 2;
@@ -33,4 +37,19 @@
   line-height: var(--text-line-height-body-on-step-1);
   color: var(--color-london);
   order: 4;
+}
+
+@media (--viewport-small) {
+  .teaser__img {
+    width: 100%;
+  }
+}
+
+@media (--viewport-big) {
+  .teaser__link {
+    display: flex;
+  }
+  .teaser__group-image {
+    margin-right: var(--grid-gutter-m);
+  }
 }

--- a/index.css
+++ b/index.css
@@ -1,0 +1,36 @@
+.teaser {
+  font-size: 1rem;
+}
+
+.teaser__link {
+  display: flex;
+  flex-direction: column;
+}
+
+.teaser__title {
+  font-size: var(--text-size-step-3);
+  line-height: var(--text-line-height-body-bold-on-step-3);
+  color: var(--color-beijing);
+  order: 2;
+}
+
+.teaser__flytitle {
+  font-size: var(--text-size-step-2);
+  line-height: var(--text-line-height-body-on-step-2);
+  color: var(--color-economist);
+  order: 1;
+}
+
+.teaser__text {
+  font-size: var(--text-size-step-1);
+  line-height: var(--text-line-height-body-on-step-1);
+  color: var(--color-beijing);
+  order: 3;
+}
+
+.teaser__datetime {
+  font-size: var(--text-size-step--1);
+  line-height: var(--text-line-height-body-on-step-1);
+  color: var(--color-london);
+  order: 4;
+}

--- a/index.es6
+++ b/index.es6
@@ -51,8 +51,9 @@ export default class Teaser extends React.Component {
   }
   render() {
     const teaserContent = [];
+    const groups = [];
     if (this.props.image) {
-      teaserContent.push((
+      groups.push((
         <img {...this.props.image}
           itemProp="image"
           className="teaser__img"
@@ -93,6 +94,7 @@ export default class Teaser extends React.Component {
           key={`teaser__text_${this.props.teaserId}`}
         >{this.props.text}</div>));
     }
+    groups.push(<div className="teaser__group-text">{teaserContent}</div>);
 
     let content = {};
     if (this.props.link) {
@@ -100,9 +102,9 @@ export default class Teaser extends React.Component {
         <a {...this.props.link}
           className="teaser__link"
           itemProp="url"
-        >{teaserContent}</a>);
+        >{groups}</a>);
     } else {
-      content = teaserContent;
+      content = groups;
     }
     return (
       <article

--- a/index.es6
+++ b/index.es6
@@ -54,11 +54,13 @@ export default class Teaser extends React.Component {
     const groups = [];
     if (this.props.image) {
       groups.push((
-        <img {...this.props.image}
-          itemProp="image"
-          className="teaser__img"
-          key={`teaser__img_${this.props.teaserId}`}
-        />));
+        <div className="teaser__group-image">
+          <img {...this.props.image}
+            itemProp="image"
+            className="teaser__img"
+            key={`teaser__img_${this.props.teaserId}`}
+          />
+        </div>));
     }
     if (this.props.flyTitle) {
       teaserContent.push((

--- a/package.json
+++ b/package.json
@@ -71,6 +71,9 @@
       },
       {
         "contents": "if(document.getElementById('mocha')){mocha.checkLeaks();mocha.run();}"
+      },
+      {
+        "contents": "</script><!-- lol html injection -->    <script type=\"text/javascript\"> (function() { var path = '//easy.myfonts.net/v2/js?sid=207020(font-family=FF+Milo+Serif+Pro)&sid=207025(font-family=FF+Milo+Serif+Pro+Med+Italic)&sid=207029(font-family=FF+Milo+Serif+Pro+Bold)&key=ADKczqjSur', protocol = ('https:' == document.location.protocol ? 'https:' : 'http:'), trial = document.createElement('script'); trial.type = 'text/javascript'; trial.async = true; trial.src = protocol + path; var head = document.getElementsByTagName(\"head\")[0]; head.appendChild(trial); })(); </script> <script type=\"text/javascript\"> (function() { var path = '//easy.myfonts.net/v2/js?sid=274518(font-family=Halifax+Regular)&sid=274519(font-family=Halifax+Light)&sid=274524(font-family=Halifax+Bold)&key=LUwLgIpMrH', protocol = ('https:' == document.location.protocol ? 'https:' : 'http:'), trial = document.createElement('script'); trial.type = 'text/javascript'; trial.async = true; trial.src = protocol + path; var head = document.getElementsByTagName(\"head\")[0]; head.appendChild(trial); })(); </script>     <script>/* end my html injection */"
       }
     ],
     "sections": [
@@ -129,6 +132,7 @@
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.4.2",
+    "@economist/component-typography": "^1.1.3",
     "babel": "^5.8.23",
     "babelify": "^6.3.0",
     "browser-sync": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.4.2",
+    "@economist/component-grid": "^1.1.0",
     "@economist/component-typography": "^1.1.3",
     "babel": "^5.8.23",
     "babelify": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,10 @@
     "watch": "parallelshell 'npm run doc:watch' 'npm run prepublish:watch' 'npm run serve'"
   },
   "dependencies": {
-    "react": "^0.13.3"
+    "react": "^0.14.0-rc"
+  },
+  "peerDependencies": {
+    "react": "~0.14.0-rc"
   },
   "devDependencies": {
     "@economist/component-devpack": "^3.4.2",


### PR DESCRIPTION
This PR provide the following implementation:

- Simulate body related style on example.css
- Styling the teaser (Pls note that in index.css there are some temporary rules of font-family that are necessary to the missing font-face and will be removed when the font will available)
- Update the package.json to solve dependecies conflict related to "react-simpletabs"