### PR TITLE
Squash react's key warning

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -58,11 +58,12 @@ export default class Teaser extends React.Component {
     const groups = [];
     if (this.props.image) {
       groups.push((
-        <div className="teaser__group-image">
+        <div className="teaser__group-image"
+          key={`teaser__group-image_${this.props.teaserId}`}
+        >
           <img {...this.props.image}
             itemProp="image"
             className="teaser__img"
-            key={`teaser__img_${this.props.teaserId}`}
           />
         </div>));
     }
@@ -113,7 +114,13 @@ export default class Teaser extends React.Component {
           }}
         />));
     }
-    groups.push(<div className="teaser__group-text">{teaserContent}</div>);
+    groups.push((
+      <div className="teaser__group-text"
+        key={`teaser__grouptext_${this.props.teaserId}`}
+      >
+        {teaserContent}
+      </div>
+    ));
 
     let content = {};
     if (this.props.link) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-teaser",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Reusable teaser",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",


### PR DESCRIPTION
React's key warning was still up, even though all the elements had the [key] prop....

Or so I thought! The image element had the prop in the `<img>`, not in the wrapper element which really is in an array.