### PR TITLE
Feature/link component type

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -14,6 +14,10 @@ export default class Teaser extends React.Component {
       link: React.PropTypes.object,
       itemType: React.PropTypes.string,
       itemProp: React.PropTypes.string,
+      LinkComponent: React.PropTypes.oneOfType([
+        React.PropTypes.func,
+        React.PropTypes.string,
+      ]),
     };
   }
   static get defaultProps() {
@@ -51,6 +55,7 @@ export default class Teaser extends React.Component {
                 ${date.getFullYear()},
                 ${date.getHours()}:${minutes}`;
       },
+      LinkComponent: 'a',
     };
   }
   render() {
@@ -124,11 +129,12 @@ export default class Teaser extends React.Component {
 
     let content = {};
     if (this.props.link) {
-      content = (
-        <a {...this.props.link}
-          className="teaser__link"
-          itemProp="url"
-        >{groups}</a>);
+      content = React.createElement(this.props.LinkComponent, {
+        ...this.props.link,
+        className: 'teaser__link',
+        itemProp: 'url',
+        children: groups,
+      });
     } else {
       content = (
         <div className="teaser__wrapper">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-teaser",
-  "version": "1.0.11",
+  "version": "1.0.13",
   "description": "Reusable teaser",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",


### PR DESCRIPTION
I'm facing an interesting problem.

component-teaser has a `link` prop, and I want to use it, but I'm not satisfied with the fact that it always gives me an `<a>` tag. So I introduced a new option, which allows me to choose what tag the link is going to be. In my case I want to use react router's `Link`, so I pass `LinkComponent: Link`, and `link: { to: 'wherever', state: {...} }`