### PR TITLE
Accept a date string+ timestamp pair instead of a Date object.

### DIFF
--- a/index.es6
+++ b/index.es6
@@ -11,6 +11,8 @@ export default class Teaser extends React.Component {
       flyTitle: React.PropTypes.string,
       title: React.PropTypes.string.isRequired,
       dateTime: React.PropTypes.instanceOf(Date),
+      dateString: React.PropTypes.string,
+      timestampISO: React.PropTypes.string,
       dateFormat: React.PropTypes.func,
       text: React.PropTypes.string,
       link: React.PropTypes.shape({
@@ -108,6 +110,15 @@ export default class Teaser extends React.Component {
           dateTime={this.props.dateTime}
           key={`teaser__datetime_${this.props.teaserId}`}
         >{this.props.dateFormat(this.props.dateTime)}</time>));
+    }
+    if (this.props.dateString && this.props.timestampISO) {
+      teaserContent.push((
+        <time
+          className="teaser__datetime"
+          itemProp="dateCreated"
+          dateTime={this.props.timestampISO}
+          key={`teaser__datetime`}
+        >{this.props.dateString}</time>));
     }
     if (this.props.text) {
       teaserContent.push((

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-teaser",
-  "version": "1.0.17",
+  "version": "1.1.0",
   "description": "Reusable teaser",
   "author": "The Economist (http://economist.com)",
   "license": "MIT",

--- a/test/index.es6
+++ b/test/index.es6
@@ -69,6 +69,22 @@ describe(`A teaser`, () => {
       elm.props.className.should.be.equal('teaser__datetime');
       elm.props.children.should.be.equal(today.toString());
     });
+    it(`renders a dateString and an ISO timestamp`, () => {
+      const today = 'someday';
+      const todayISO = 'somedayISO';
+      const teaser = TestUtils.renderIntoDocument(
+        <Teaser
+          title="Required"
+          teaserId={'1'}
+          dateString={today}
+          timestampISO={todayISO}
+        />
+      );
+      const elm = TestUtils.findRenderedDOMComponentWithClass(
+        teaser, 'teaser__datetime');
+      elm.props.children.should.equal('someday');
+      elm.props.dateTime.should.equal('somedayISO');
+    });
     it(`it renders a text`, () => {
       const teaser = TestUtils.renderIntoDocument(
         <Teaser


### PR DESCRIPTION
This was created especially for the revamp.

There are some timestamp issues related to timezones, summer times, etc, so the approach will be to use moment-timezone on the server to format dates. This means that component-teaser should be able to accept a date string.