### PR TITLE
feat: allow for extra children in the teaser's text group

### DIFF
--- a/src/example.css
+++ b/src/example.css
@@ -6,6 +6,10 @@
   line-height: var(--text-line-height-sans-on-step-0);
 }
 
+.example-extra {
+  order: 4;
+}
+
 @media screen and (min-width: 800px) {
   .teaser {
     font-size: 20px;

--- a/src/example.js
+++ b/src/example.js
@@ -24,6 +24,7 @@ export default (
       }}
       itemType="http://schema.org/BlogPosting"
       itemProp="blogPost"
+      extraGroupText={(<em className="example-extra">You can add extra items to the text group</em>)}
     />
   </div>
 );

--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,7 @@ import React from 'react';
 export default class Teaser extends React.Component {
   static get propTypes() {
     return {
-      image: React.PropTypes.shape({
-        src: React.PropTypes.string,
-      }),
+      mainImage: React.PropTypes.string,
       section: React.PropTypes.string,
       flyTitle: React.PropTypes.string,
       title: React.PropTypes.string.isRequired,
@@ -13,7 +11,8 @@ export default class Teaser extends React.Component {
       dateString: React.PropTypes.string,
       timestampISO: React.PropTypes.string,
       dateFormat: React.PropTypes.func,
-      text: React.PropTypes.string,
+      text: React.PropTypes.node,
+      extraGroupText: React.PropTypes.node,
       link: React.PropTypes.shape({
         href: React.PropTypes.string,
       }),
@@ -78,13 +77,12 @@ export default class Teaser extends React.Component {
   render() {
     const teaserContent = [];
     const groups = [];
-    const imageSrc = this.props.image && this.props.image.src;
     let imageClasses = [ 'teaser__group-image' ];
-    if (!imageSrc) {
+    if (!this.props.mainImage) {
       imageClasses = imageClasses.concat([ 'teaser__group-image--empty' ]);
     }
-    const image = imageSrc ?
-      (<img {...this.props.image} itemProp="image" className="teaser__img" />) :
+    const image = this.props.mainImage ?
+      (<img {...this.props.mainImage} itemProp="image" className="teaser__img" />) :
       null;
     groups.push((
       <div className={imageClasses.join(' ')} key="group-image">
@@ -140,17 +138,17 @@ export default class Teaser extends React.Component {
           className="teaser__text"
           itemProp="description"
           key="text"
-          /* eslint-disable react/no-danger */
-          dangerouslySetInnerHTML={{
-            '__html': this.props.text,
-          }}
-        />));
+        >
+          {this.props.text}
+        </div>
+      ));
     }
     groups.push((
       <div className="teaser__group-text"
         key="grouptext"
       >
         {teaserContent}
+        {this.props.extraGroupText}
       </div>
     ));
     const content = this.wrapGroupsInLink(groups);


### PR DESCRIPTION
BREAKING CHANGE: image has been renamed to mainImage
BREAKING CHANGE: text is no longer an HTML field, now it's React.PropTypes.node