### PR TITLE
fix: remove deprecated proptype check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import TeaserImage from './teaser-image';
-import TeaserLink from './teaser-link';
-import TeaserPublishDate from './teaser-publish-date';
-import TeaserTitle from './teaser-title';
 
 export default function Teaser({
   className,

--- a/src/index.js
+++ b/src/index.js
@@ -33,49 +33,6 @@ if (process.env.NODE_ENV !== 'production') {
     className: React.PropTypes.string,
     itemType: React.PropTypes.string,
     itemProp: React.PropTypes.string,
-    children: (props, propName, componentName) => {
-      // not required: TeaserLink, TeaserText, TeaserFlyTitle, TeaserSection
-      // required: TeaserImage, TeaserTitle, TeaserPublishDate
-      let children = [];
-      if (props.children) {
-        if (Array.isArray(props.children)) {
-          let teaserLinkExists = false;
-          props.children.forEach((child, index) => {
-            if (child.type === TeaserLink) {
-              teaserLinkExists = true;
-              children = props.children[index].props.children;
-            }
-          });
-
-          if (teaserLinkExists === false) {
-            children = props.children;
-          }
-        } else {
-          children = props.children.props.children;
-        }
-      }
-
-      let teaserImageExists = false;
-      let teaserPublishDateExists = false;
-      let teaserTitleExists = false;
-      children.forEach((child) => {
-        teaserImageExists = teaserImageExists || child.type === TeaserImage;
-        teaserPublishDateExists = teaserPublishDateExists || child.type === TeaserPublishDate;
-        teaserTitleExists = teaserTitleExists || child.type === TeaserTitle;
-      });
-
-      if (teaserImageExists === false) {
-        return new Error(`Invalid component TeaserImage not specified in
-          ${ propName } for ${ componentName }.`);
-      } else if (teaserPublishDateExists === false) {
-        return new Error(`Invalid component TeaserPublishDate not specified in
-          ${ propName } for ${ componentName }.`);
-      } else if (teaserTitleExists === false) {
-        return new Error(`Invalid component TeaserTitle not specified in
-          ${ propName } for ${ componentName }.`);
-      }
-
-      return null;
-    },
+    children: React.PropTypes.node,
   };
 }


### PR DESCRIPTION
This way of checking proptypes has been deprecated in React 15. Also, it's making sure it has a certain number of components, which is totally dumb. And, it crashes when one of the children is undefined. React.PropTypes.node it is!